### PR TITLE
Reduce calls to Apple

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -431,7 +431,7 @@ module Spaceship
     #####################################################
 
     def devices(mac: false, include_disabled: false)
-      result = paging do |page_number|
+      @devices_cache ||= paging do |page_number|
         r = request(:post, "account/#{platform_slug(mac)}/device/listDevices.action", {
             teamId: team_id,
             pageNumber: page_number,
@@ -444,7 +444,7 @@ module Spaceship
 
       csrf_cache[Spaceship::Device] = self.csrf_tokens
 
-      result
+      @devices_cache
     end
 
     def devices_by_class(device_class, include_disabled: false)

--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -496,16 +496,20 @@ module Spaceship
     #####################################################
 
     def certificates(types, mac: false)
-      paging do |page_number|
-        r = request(:post, "account/#{platform_slug(mac)}/certificate/listCertRequests.action", {
-          teamId: team_id,
-          types: types.join(','),
-          pageNumber: page_number,
-          pageSize: page_size,
-          sort: 'certRequestStatusCode=asc'
-        })
-        parse_response(r, 'certRequests')
+      unless @certificates_cache
+        @certificates_cache = paging do |page_number|
+          r = request(:post, "account/#{platform_slug(mac)}/certificate/listCertRequests.action", {
+            teamId: team_id,
+            types: types.join(','),
+            pageNumber: page_number,
+            pageSize: page_size,
+            sort: 'certRequestStatusCode=asc'
+          })
+          parse_response(r, 'certRequests')
+        end
       end
+
+      @certificates_cache.dup
     end
 
     def create_certificate!(type, csr, app_id = nil, mac = false)

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -478,6 +478,7 @@ module Spaceship
         end
 
         # We need to fetch the provisioning profile again, as the ID changes
+        @client.clear_provisioning_profiles_cache
         profile = Spaceship::ProvisioningProfile.all(mac: mac?, alternative_client: @client).find do |p|
           p.name == self.name # we can use the name as it's valid
         end


### PR DESCRIPTION
**CSRF**
1.  The CSRF token cache was being recreated with an empty hash each time it was requested.  Fixed so that it will return an existing cache if it exists.
2.  When loading the CSRF token 2 requests were being made as back in 2016 the first CSRF token was not valid.  Today the first CSRF token returned is valid for the Devices and Profiles scenarios, so removing the second call for loading the CSRF token.
3.  To get the CSRF token calls are made to the "all" method of the type.  Frequently this will have already been invoked but the CSRF token was never stored.  For Devices and Profiles, updated to store the CSRF token when the all method is invoked so it does not need to be retrieved later.

Notes:
- This change saves us:
    2 calls per device being registered
    4 calls per profile being updated
- For #3 above, to merge this into Fastlane mainline we will likely need to do this CSRF token caching on other types as well.  These types include:
	Spaceship::App
	Spaceship::AppGroup
	Spaceship::Merchant
	Spaceship::Passbook
	Spaceship::WebsitePush
	Spaceship::Portal::Persons.all
	Spaceship::Certificate

**Caching Devices**
In our scenario, the devices list is primarily loaded by Fastlane to see if the device being created already exists in the Apple Developer account.

With this change the devices list is only loaded once rather than once per device being added to the Apple Developer account.

This change saves us 1 call per device being added.